### PR TITLE
Add augment function

### DIFF
--- a/examples/augment.ts
+++ b/examples/augment.ts
@@ -1,0 +1,13 @@
+import { augment } from "..";
+
+const { Apple, Pizza, Static } = augment({
+    Apple: (size: number) => ({ size }),
+    Pizza: (radius: number) => ({ radius }),
+    Static: { Somedata: 10 }
+  },
+  () => ({createdAt: new Date()})
+)
+
+console.log(Apple(10).createdAt); // = Date, ok
+console.log(Pizza(10).createdAt); // = Date, ok
+console.log(Static.createdAt); // type not augmented, thus createdAt is not added

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "ES2022",
-    "target": "es6",
+    "target": "ES2020",
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
Added a very useful function inspired by [Variant's augment](https://paarthenon.github.io/variant/docs/next/book/augment)

Gets rid of repeating property definitions and can be used for some powerful automations, like for instance adding unique ids, creation date, recording the context where the variant was created (e.g. start/end locations inside a parser), and much more

Felt like an essential feature to have 👍 